### PR TITLE
fix error on python 2.7.6 : TypeError: coercing to Unicode

### DIFF
--- a/gui/qdialog_d.py
+++ b/gui/qdialog_d.py
@@ -277,7 +277,7 @@ class QDialogDaemon(QDialogUI):
         selection[0x02] = localhost_word
         ch_parts = [0x08, 0x20 if ip_flag else 0x10, 0x40]
         # Set customized module if exists
-        if os.path.isfile(self.custom):
+        if (self.custom != None and os.path.isfile(self.custom)):
             ch_parts.insert(0, 0x04)
         slices = self.slices[ip_flag]
         for i, part in enumerate(ch_parts):


### PR DESCRIPTION
The log is：
Traceback (most recent call last):
  File "/home/wbl/dev/app/network/huhamhire-hosts/gui/qdialog_slots.py", line 228, in on_MakeHosts_clicked
    self.make_hosts("system")
  File "/home/wbl/dev/app/network/huhamhire-hosts/gui/qdialog_d.py", line 204, in make_hosts
    self.set_config_bytes(mode)
  File "/home/wbl/dev/app/network/huhamhire-hosts/gui/qdialog_d.py", line 282, in set_config_bytes
    if (self.custom == None and os.path.isfile(self.custom)):
  File "/usr/lib/python2.7/genericpath.py", line 29, in isfile
    st = os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found
