### PR TITLE
Fix issue #26 TypeError: coercing to Unicode: need string or buffer, NoneType found

### DIFF
--- a/hoststool.py
+++ b/hoststool.py
@@ -122,7 +122,9 @@ class UtilLauncher(object):
         .. note:: This is a `classmethod`.
         """
         main = gui.HostsUtil()
-        main.custom = UtilLauncher.get_custom_conf_path()
+        path = UtilLauncher.get_custom_conf_path()
+        if path is not None:
+            main.custom = path
         main.start()
 
     @classmethod


### PR DESCRIPTION
If we don't have ~/.custom.hosts or ~/custom.hosts, get_custom_conf_path
will return None and overwrite the default self.custom value.

Issue: 26
